### PR TITLE
Adding support for Firefox installed from the Microsoft Store and to custom locations

### DIFF
--- a/scripts/install/install_windows.go
+++ b/scripts/install/install_windows.go
@@ -57,7 +57,7 @@ func GetChromeManifestPaths() []string {
 
 func GetFirefoxManifestPaths() []string {
 	return append(
-		[]string{`C:\Program Files\Mozilla Firefox\FirefoxPwdMgrHostApp_manifest.json`},
+		[]string{`C:\ProgramData\Mozilla Firefox\FirefoxPwdMgrHostApp_manifest.json`},
 		getWindowsManifestPaths(FIREFOX_MANIFEST_KEYS)...,
 	)
 }

--- a/scripts/install/main.go
+++ b/scripts/install/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +14,17 @@ const (
 )
 
 func main() {
-	firefoxManifests := GetFirefoxManifestPaths()
+	// Arguments
+	var customFirefoxManifest string
+
+	flag.StringVar(&customFirefoxManifest, "manifest-path", "", "Specify a manifest location to register the extension with.")
+	flag.Parse()
+
+	// If a custom manifest path is specified, use it instead of the default one
+	firefoxManifests := []string{customFirefoxManifest}
+	if customFirefoxManifest == "" {
+		firefoxManifests = GetFirefoxManifestPaths()
+	}
 
 	for _, manifestPath := range firefoxManifests {
 		manifest, err := ReadManifest(manifestPath)

--- a/scripts/install/manifest.go
+++ b/scripts/install/manifest.go
@@ -46,7 +46,7 @@ func (manifest *Manifest) Write(path string) error {
 }
 
 func (manifest *Manifest) Register(path string) error {
-	// Create folders if missing and write manifest
+	// Create parent folders if missing
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	if err != nil {
 		return err

--- a/scripts/install/manifest.go
+++ b/scripts/install/manifest.go
@@ -46,7 +46,14 @@ func (manifest *Manifest) Write(path string) error {
 }
 
 func (manifest *Manifest) Register(path string) error {
-	err := manifest.Write(path)
+	// Create folders if missing and write manifest
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil {
+		return err
+	}
+
+	// Write manifest
+	err = manifest.Write(path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi, I found this extension a few month ago and its really great!

This PR consist in three small changes to hopefully fix #40:

- Changing the default manifest location to `Program Data` for better compatibility when Firefox is installed in another location (e.g. the `Microsoft Store` or an `E:\` drive)  
- Added a way for the user/dev to specify a custom manifest install location with the `--manifest-path` parameter (mostly if the need arise)
- Creating parent folders when they are missing (e.g. the ` Mozilla Firefox`  directory if it does not exists) 

It may also fix #43 and #38 although the authors would have to test it first.

Some of the changes might be controversial, so please feel free to provide feedback and I'll change it